### PR TITLE
add test and fix for `anyone` functionality

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -41,7 +41,7 @@ module.exports = {
   rules: function (rules, user, method) {
     return (rules || [])
       .filter(function (rule) {
-        return rule.user === user && rule.method === method;
+        return (!rule.user || rule.user === user) && rule.method === method;
       });
   }
 

--- a/test/integration/can.js
+++ b/test/integration/can.js
@@ -281,4 +281,31 @@ describe('Integration: Can API', function () {
 
   });
 
+  describe('Anyone', function() {
+    var doctor;
+    var drHouse, drJeckyl, patient;
+    beforeEach(function () {
+      drJeckyl = new Doctor();
+      drHouse = new Doctor();
+      patient = new Patient();
+      Patient.authorize.anyone.to.read.when(function (genericUser) {
+        return this.appointments.filter(function (appointment) {
+          return appointment.doctor === genericUser;
+        });
+      });
+      patient.appointments = [{doctor: drHouse}];
+    });
+
+    it('allows anyone with proper permissions to read', function() {
+      return expect(drHouse.can.read(patient))
+        .to.eventually.equal(null);
+    });
+
+    it('rejects anyone without proper permissions', function() {
+      return expect(drJeckyl.can.read(patient))
+        .to.be.rejectedWith(AuthorizationError);
+    });
+
+  });
+
 });


### PR DESCRIPTION
Thanks for making this useful repo available!
# Background

When assigning permissions to models, it is possible to use `.anyone` instead of assigning permissions to a specific (type of) user. Example:

``` js
var Post = backbone.Model.extend();
Post.authorize.anyone.to.read.when(function(user) {
  //return true if the user is friends with the author
  return user.get(friends).indexOf(this.author) >= 0;
}
```

This works very well when multiple user-types get limited access to a resource based on the same criteria.
# Problem

When `anyone` is used in the authorization chain, then no rules are ever matched for any users. Here is a screenshot of the results from a test that I added to `test/integration/can.js`
![screen shot 2015-04-15 at 5 54 41 pm](https://cloud.githubusercontent.com/assets/5280961/7172343/f8fab510-e39a-11e4-87d7-0bf3836e948e.png)
# Cause

`resolver.js` filters out roles that do not have the same user as the current user.
# Solution

allow rules to be matched if the rule's user is the same as the current user, or if it not `truthy`.
# Discussion

I've also added a couple of tests to illustrate the problem and solution.
